### PR TITLE
Stored message in event and used the event to get message during composing

### DIFF
--- a/src/MtMail/Event/ComposerEvent.php
+++ b/src/MtMail/Event/ComposerEvent.php
@@ -51,7 +51,7 @@ class ComposerEvent extends Event
     protected $viewModel;
 
     /**
-     * @param  \Zend\Mail\Message $message
+     * @param  Message $message
      * @return self
      */
     public function setMessage(Message $message)
@@ -62,10 +62,14 @@ class ComposerEvent extends Event
     }
 
     /**
-     * @return \Zend\Mail\Message
+     * @return Message
      */
     public function getMessage()
     {
+        if (!$this->message instanceof Message) {
+            $this->setMessage(new Message);
+        }
+
         return $this->message;
     }
 

--- a/src/MtMail/Service/Composer.php
+++ b/src/MtMail/Service/Composer.php
@@ -126,15 +126,13 @@ class Composer implements EventManagerAwareInterface
         $event->setTemplate($template);
         $em = $this->getEventManager();
 
-        // 1. create message
-        $message = new Message();
-        $event->setMessage($message);
+        // 1. Trigger pre event
         $em->trigger(ComposerEvent::EVENT_COMPOSE_PRE, $event);
 
         // 2. inject headers
         $em->trigger(ComposerEvent::EVENT_HEADERS_PRE, $event);
         foreach ($headers as $name => $value) {
-            $message->getHeaders()->addHeaderLine($name, $value);
+            $event->getMessage()->getHeaders()->addHeaderLine($name, $value);
         }
         $em->trigger(ComposerEvent::EVENT_HEADERS_POST, $event);
 
@@ -173,10 +171,10 @@ class Composer implements EventManagerAwareInterface
 
         // 5. inject body into message
         $event->setBody($body);
-        $message->setBody($body);
+        $event->getMessage()->setBody($body);
 
         $em->trigger(ComposerEvent::EVENT_COMPOSE_POST, $event);
 
-        return $message;
+        return $event->getMessage();
     }
 }


### PR DESCRIPTION
@mtymek
Look at this:
https://github.com/juriansluiman/SlmMail/blob/master/docs/Mailgun.md

Message should not necessarily be instance of `Zend\Mail\Message`. For mailgun, it can be instance of `SlmMail\Mail\Message\Mailgun`. So , if we use mailgun, we can do something like this:

``` php
$composer->getEventManager()->attach(ComposerEvent::EVENT_COMPOSE_PRE, function($event) {
    $event->setMessage(new \SlmMail\Mail\Message\Mailgun);
});
```
