### PR TITLE
Allow header object injection.

### DIFF
--- a/doc/Composer Plugins.md
+++ b/doc/Composer Plugins.md
@@ -44,6 +44,14 @@ return [
 
 `DefaultHeaders` is hooked to `headers.pre` event.
 
+In some situations the `GenericHeader` class of zend-mail will not fit your needs. For example when a subject contains
+utf-8 characters. In this case it is not possible to use the configuration to add default headers. You can either call
+the `setHeaders` method of the `DefaultHeaders` plugin. Be aware of the fact that this will overwrite the default
+plugins from the configuration!
+
+A better approach would be to create a custom [Template](Template Manager.md) which implements the
+`HeadersProviderInterface`
+
 ### Layout
 
 A common requirement for e-mail system is a layout shared between all messages.

--- a/doc/Template Manager.md
+++ b/doc/Template Manager.md
@@ -15,7 +15,7 @@ Available interfaces
 * **HtmlTemplateInterface** - template provides view script to be rendered as `text/html` message part
 * **TextTemplateInterface** - template provides view script to be rendered as `text/plain` message part
 * **LayoutProviderInterface** - template has a separate layout (see example below)
-* **HeadersProviderInterface** - template provides specific headers (`Subject:`)
+* [**HeadersProviderInterface**](#HeadersProviderInterface) - template provides specific headers (`Subject:`)
 
 MtMail uses templates internally. When passing view script name, as in this example:
 
@@ -86,4 +86,32 @@ Finally, usage:
 ```php
 $headers = array(...);
 $mail = $this->mtMail()->compose($headers, 'FooBarTemplate');
+```
+
+### HeadersProviderInterface
+ 
+This interface allows the template to provide default headers to be set when the template is used. This can be either an
+object or simple configuration as shown in the example below.
+
+```php
+namespace FooModule\EmailTemplate;
+
+use MtMail\Template\HtmlTemplateInterface;
+use MtMail\Template\LayoutProviderInterface;
+use MtMail\Template\HeadersProviderInterface;
+
+class FooBarTemplate implements HtmlTemplateInterface, LayoutProviderInterface, HeadersProviderInterface
+{
+    /* .. */
+
+    public function getHeaders()
+    {
+        $subject = (new Subject())->setSubject('Hello!');
+        
+        return array(
+           'from' => 'My Website <information-no-reply@mywebsite.com>',
+           'subject' => $subject,
+        )
+    }
+}
 ```

--- a/src/ComposerPlugin/DefaultHeaders.php
+++ b/src/ComposerPlugin/DefaultHeaders.php
@@ -38,9 +38,8 @@ class DefaultHeaders extends AbstractListenerAggregate implements PluginInterfac
     }
 
     /**
-     * @param $message
-     * @param $header
-     * @param $value
+     * @param Message $message
+     * @param HeaderInterface[]|string[] $headers
      */
     private function addHeaders(Message $message, $headers)
     {

--- a/src/ComposerPlugin/DefaultHeaders.php
+++ b/src/ComposerPlugin/DefaultHeaders.php
@@ -14,6 +14,7 @@ use MtMail\Template\HeadersProviderInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\AbstractListenerAggregate;
 use Zend\Mail\Header\HeaderInterface;
+use Zend\Mail\Message;
 
 class DefaultHeaders extends AbstractListenerAggregate implements PluginInterface
 {
@@ -29,21 +30,25 @@ class DefaultHeaders extends AbstractListenerAggregate implements PluginInterfac
     public function injectDefaultHeaders(ComposerEvent $event)
     {
         $message = $event->getMessage();
-        foreach ($this->headers as $header => $value) {
+        $this->addHeaders($message, $this->headers);
+
+        if ($event->getTemplate() instanceof HeadersProviderInterface) {
+            $this->addHeaders($message, $event->getTemplate()->getHeaders());
+        }
+    }
+
+    /**
+     * @param $message
+     * @param $header
+     * @param $value
+     */
+    private function addHeaders(Message $message, $headers)
+    {
+        foreach ($headers as $header => $value) {
             if ($value instanceof HeaderInterface) {
                 $message->getHeaders()->addHeader($value);
             } else {
                 $message->getHeaders()->addHeaderLine($header, $value);
-            }
-        }
-
-        if ($event->getTemplate() instanceof HeadersProviderInterface) {
-            foreach ($event->getTemplate()->getHeaders() as $header => $value) {
-                if ($value instanceof HeaderInterface) {
-                    $message->getHeaders()->addHeader($value);
-                } else {
-                    $message->getHeaders()->addHeaderLine($header, $value);
-                }
             }
         }
     }

--- a/src/ComposerPlugin/DefaultHeaders.php
+++ b/src/ComposerPlugin/DefaultHeaders.php
@@ -13,6 +13,7 @@ use MtMail\Event\ComposerEvent;
 use MtMail\Template\HeadersProviderInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\AbstractListenerAggregate;
+use Zend\Mail\Header\HeaderInterface;
 
 class DefaultHeaders extends AbstractListenerAggregate implements PluginInterface
 {
@@ -29,12 +30,20 @@ class DefaultHeaders extends AbstractListenerAggregate implements PluginInterfac
     {
         $message = $event->getMessage();
         foreach ($this->headers as $header => $value) {
-            $message->getHeaders()->addHeaderLine($header, $value);
+            if ($value instanceof HeaderInterface) {
+                $message->getHeaders()->addHeader($value);
+            } else {
+                $message->getHeaders()->addHeaderLine($header, $value);
+            }
         }
 
         if ($event->getTemplate() instanceof HeadersProviderInterface) {
             foreach ($event->getTemplate()->getHeaders() as $header => $value) {
-                $message->getHeaders()->addHeaderLine($header, $value);
+                if ($value instanceof HeaderInterface) {
+                    $message->getHeaders()->addHeader($value);
+                } else {
+                    $message->getHeaders()->addHeaderLine($header, $value);
+                }
             }
         }
     }

--- a/test/MtMailTest/ComposerPlugin/DefaultHeadersTest.php
+++ b/test/MtMailTest/ComposerPlugin/DefaultHeadersTest.php
@@ -11,9 +11,11 @@ namespace MtMailTest\Plugin;
 
 use MtMail\Event\ComposerEvent;
 use MtMail\ComposerPlugin\DefaultHeaders;
+use MtMailTest\Test\HeaderObjectProviderTemplate;
 use MtMailTest\Test\HeadersProviderTemplate;
 use PHPUnit\Framework\TestCase;
 use Zend\Mail\Headers;
+use Zend\Mail\Header\Subject;
 use Zend\Mail\Message;
 
 class DefaultHeadersTest extends TestCase
@@ -59,6 +61,35 @@ class DefaultHeadersTest extends TestCase
         $template = new HeadersProviderTemplate();
         $message = new Message();
         $message->setHeaders($headers->reveal());
+        $event = new ComposerEvent();
+        $event->setMessage($message);
+        $event->setTemplate($template);
+        $this->plugin->injectDefaultHeaders($event);
+    }
+
+    public function testPluginCanInjectHeaderObjects()
+    {
+        $subject = (new Subject())->setSubject('Hello!');
+        $this->plugin->setHeaders([
+            'subject' => $subject,
+        ]);
+
+        $headers = $this->getMock('Zend\Mail\Headers', ['addHeader']);
+        $headers->expects($this->at(0))->method('addHeader')->with($subject);
+        $message = new Message();
+        $message->setHeaders($headers);
+        $event = new ComposerEvent();
+        $event->setMessage($message);
+        $this->plugin->injectDefaultHeaders($event);
+    }
+
+    public function testPluginCanInjectTemplateSpecificHeaderObjects()
+    {
+        $headers = $this->getMock('Zend\Mail\Headers', ['addHeader']);
+        $headers->expects($this->at(0))->method('addHeader')->with((new Subject())->setSubject('Default subject'));
+        $template = new HeaderObjectProviderTemplate();
+        $message = new Message();
+        $message->setHeaders($headers);
         $event = new ComposerEvent();
         $event->setMessage($message);
         $event->setTemplate($template);

--- a/test/MtMailTest/Test/HeaderObjectProviderTemplate.php
+++ b/test/MtMailTest/Test/HeaderObjectProviderTemplate.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * MtMail - e-mail module for Zend Framework 2
+ *
+ * @link      http://github.com/mtymek/MtMail
+ * @copyright Copyright (c) 2013-2014 Mateusz Tymek
+ * @license   BSD 2-Clause
+ */
+
+namespace MtMailTest\Test;
+
+use MtMail\Template\HeadersProviderInterface;
+use MtMail\Template\HtmlTemplateInterface;
+use Zend\Mail\Header\Subject;
+
+class HeaderObjectProviderTemplate implements HtmlTemplateInterface, HeadersProviderInterface
+{
+
+    /**
+     * @return string
+     */
+    public function getHtmlTemplateName()
+    {
+        return 'template';
+    }
+
+    /**
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return [
+            'subject' => (new Subject())->setSubject('Default subject'),
+        ];
+    }
+}


### PR DESCRIPTION
Subject headers containing non ASCII characters are not supported by
the GenericHeader. Therefor it is required to be able to provide objects
for headers.
