### PR TITLE
Remove setEventManager from class Composer

### DIFF
--- a/src/Service/Composer.php
+++ b/src/Service/Composer.php
@@ -16,7 +16,6 @@ use MtMail\Template\HtmlTemplateInterface;
 use MtMail\Template\TemplateInterface;
 use MtMail\Template\TextTemplateInterface;
 use Zend\EventManager\EventManager;
-use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
 use Zend\Mail\Message;
 use Zend\View\Model\ModelInterface;
@@ -24,7 +23,7 @@ use Zend\Mime\Message as MimeMessage;
 use Zend\Mime\Part as MimePart;
 use Zend\View\Model\ViewModel;
 
-class Composer implements EventManagerAwareInterface
+class Composer
 {
     /**
      * @var RendererInterface
@@ -44,19 +43,6 @@ class Composer implements EventManagerAwareInterface
     public function __construct(RendererInterface $renderer)
     {
         $this->renderer = $renderer;
-    }
-
-    /**
-     * Inject an EventManager instance
-     *
-     * @param  EventManagerInterface $eventManager
-     * @return self
-     */
-    public function setEventManager(EventManagerInterface $eventManager)
-    {
-        $this->eventManager = $eventManager;
-
-        return $this;
     }
 
     /**

--- a/test/MtMailTest/Service/ComposerTest.php
+++ b/test/MtMailTest/Service/ComposerTest.php
@@ -70,20 +70,15 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('MAIL_SUBJECT', $message->getSubject());
     }
 
-    public function testServiceIsEventManagerAware()
-    {
-        $em = new EventManager();
-        $this->service->setEventManager($em);
-        $this->assertEquals($em, $this->service->getEventManager());
-    }
-
     public function testComposeTriggersEvents()
     {
         $renderer = $this->prophesize(RendererInterface::class);
         $renderer->render(Argument::type(ModelInterface::class))
             ->willReturn('MAIL_BODY');
 
-        $em = new EventManager();
+        $service = new Composer($renderer->reveal());
+        $em = $service->getEventManager();
+        
         $listener = function ($event) {
             $this->assertInstanceof(
                 ComposerEvent::class,
@@ -118,8 +113,7 @@ class ComposerTest extends \PHPUnit\Framework\TestCase
             $listener
         );
 
-        $service = new Composer($renderer->reveal());
-        $service->setEventManager($em);
+
         $template = new HtmlTemplate();
         $service->compose([], $template, new ViewModel());
 


### PR DESCRIPTION
Prevent bugs caused by swapping out the eventmanager
Fixes issues #41 and #36 
Technically this is a breaking change but I think removing setEventManager is fine because:
- the behavior it fixes was introduced by accident at some point (by the ServiceManager?)
- probably nobody calls setEventManager because they would be hit by those bugs and not be able to use the plugins
- I don't see a reason why you'd want to attach the global EventManager, this is also discouraged.

I wrote a test but it was rather circular. You'd need a pretty big end-to-end test of the real ServiceManager + real Composer + a mocked plugin to test this case.